### PR TITLE
Refactor/api hook

### DIFF
--- a/src/api/requests.js
+++ b/src/api/requests.js
@@ -5,6 +5,9 @@ export const requests = {
   fetchTrending: '/trending/all/week',
   fetchTopRated: '/movie/top_rated',
 
+  fetchTrendingMovies: '/trending/movie/week',
+  fetchTrendingTV: '/trending/tv/week',
+
   fetchReleaseDates: (movieId) => `/movie/${movieId}/release_dates`,
   fetchWatchlist: (accountId) => `/account/${accountId}/watchlist/movies`,
 

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,6 +1,6 @@
 import './Banner.css';
 import { useEffect, useState, useMemo } from 'react';
-import { useMixedContent } from '../../hooks/useMixedContent';
+import { useMixedContentData } from '../../hooks/useMixedContentData';
 import { instance } from '../../api/axios';
 import { requests } from '../../api/requests';
 import MyListIcon from '../../assets/icon-mylist.svg';
@@ -9,7 +9,7 @@ import InfoIcon from '../../assets/icon-info.svg';
 import { useMyList } from '../../pages/MyList/MyListContext';
 
 const Banner = ({ onInfoClick, type = 'all' }) => {
-  const { rawMovies, rawTVs } = useMixedContent(type);
+  const { rawMovies, rawTVs } = useMixedContentData(type);
   const [previews, setPreviews] = useState([]);
   const [content, setContent] = useState(null);
 

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -60,22 +60,33 @@ const Banner = ({ onInfoClick, type = 'all' }) => {
   }, [combined]);
 
   useEffect(() => {
-    instance
-      .get(requests.fetchTrending)
-      .then((res) => {
+    const fetchPreviews = async () => {
+      try {
+        const url =
+          type === 'tv'
+            ? requests.fetchTrendingTV
+            : type === 'movie'
+              ? requests.fetchTrendingMovies
+              : requests.fetchTrending;
+
+        const res = await instance.get(url);
         const mapped = res.data.results
           .filter((item) => item.poster_path)
           .map((item) => ({
             id: item.id,
             title: item.title || item.name,
             image: `https://image.tmdb.org/t/p/w300${item.poster_path}`,
-            media_type: item.media_type,
+            media_type: item.media_type || (item.title ? 'movie' : 'tv'),
             genre_ids: item.genre_ids,
           }));
         setPreviews(mapped);
-      })
-      .catch((err) => console.error('트렌딩 썸네일 불러오기 실패:', err));
-  }, []);
+      } catch (err) {
+        console.error('프리뷰 콘텐츠 로딩 실패:', err);
+      }
+    };
+
+    fetchPreviews();
+  }, [type]);
 
   if (!content) return null;
 

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,5 +1,6 @@
 import './Banner.css';
 import { useEffect, useState, useMemo } from 'react';
+import { useMixedContent } from '../../hooks/useMixedContent';
 import { instance } from '../../api/axios';
 import { requests } from '../../api/requests';
 import MyListIcon from '../../assets/icon-mylist.svg';
@@ -8,8 +9,7 @@ import InfoIcon from '../../assets/icon-info.svg';
 import { useMyList } from '../../pages/MyList/MyListContext';
 
 const Banner = ({ onInfoClick }) => {
-  const [rawMovies, setRawMovies] = useState([]);
-  const [rawTVs, setRawTVs] = useState([]);
+  const { rawMovies, rawTVs } = useMixedContent();
   const [previews, setPreviews] = useState([]);
   const [content, setContent] = useState(null);
 
@@ -31,58 +31,6 @@ const Banner = ({ onInfoClick }) => {
       });
     }
   };
-
-  useEffect(() => {
-    const fetchMixedContent = async () => {
-      try {
-        const [
-          netflixRes,
-          actionMovieRes,
-          comedyMovieRes,
-          horrorMovieRes,
-          romanceMovieRes,
-
-          actionTVRes,
-          comedyTVRes,
-          docTVRes,
-          dramaTVRes,
-          realityTVRes,
-        ] = await Promise.all([
-          instance.get(requests.fetchNetflixOriginals),
-          instance.get(requests.fetchActionMovies),
-          instance.get(requests.fetchComedyMovies),
-          instance.get(requests.fetchHorrorMovies),
-          instance.get(requests.fetchRomanceMovies),
-
-          instance.get(requests.fetchActionAdventureTV),
-          instance.get(requests.fetchComedyTV),
-          instance.get(requests.fetchDocumentaryTV),
-          instance.get(requests.fetchDramaTV),
-          instance.get(requests.fetchRealityTV),
-        ]);
-
-        setRawMovies([
-          ...netflixRes.data.results,
-          ...actionMovieRes.data.results,
-          ...comedyMovieRes.data.results,
-          ...horrorMovieRes.data.results,
-          ...romanceMovieRes.data.results,
-        ]);
-
-        setRawTVs([
-          ...actionTVRes.data.results,
-          ...comedyTVRes.data.results,
-          ...docTVRes.data.results,
-          ...dramaTVRes.data.results,
-          ...realityTVRes.data.results,
-        ]);
-      } catch (error) {
-        console.error('배너 콘텐츠 로딩 실패:', error);
-      }
-    };
-
-    fetchMixedContent();
-  }, []);
 
   const movieList = useMemo(() => {
     return rawMovies.map((item) => ({

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -8,8 +8,8 @@ import PlayIcon from '../../assets/icon-modal-play.svg';
 import InfoIcon from '../../assets/icon-info.svg';
 import { useMyList } from '../../pages/MyList/MyListContext';
 
-const Banner = ({ onInfoClick }) => {
-  const { rawMovies, rawTVs } = useMixedContent();
+const Banner = ({ onInfoClick, type = 'all' }) => {
+  const { rawMovies, rawTVs } = useMixedContent(type);
   const [previews, setPreviews] = useState([]);
   const [content, setContent] = useState(null);
 

--- a/src/components/DetailModal/DetailModal.jsx
+++ b/src/components/DetailModal/DetailModal.jsx
@@ -1,51 +1,11 @@
 import './DetailModal.css';
-import { useEffect, useState } from 'react';
-import { instance } from '../../api/axios';
-import { requests } from '../../api/requests';
 import { useMyList } from '../../pages/MyList/MyListContext';
 import MyListIcon from '../../assets/icon-mylist-plus.svg';
 import ShareIcon from '../../assets/icon-share.svg';
+import { useDetailData } from '../../hooks/useDetailData';
 
-const DetailModal = (props) => {
-  const { isOpen, onClose, movieId, movieType } = props;
-  const [movie, setMovie] = useState(null);
-
-  useEffect(() => {
-    if (!isOpen || !movieId || !movieType) return;
-
-    const fetchDetails = async () => {
-      try {
-        const url =
-          movieType === 'tv'
-            ? requests.fetchTVDetails(movieId)
-            : requests.fetchMovieDetails(movieId);
-
-        const res = await instance.get(url);
-        const data = res.data;
-
-        const subtitle = data.release_date
-          ? `개봉일: ${data.release_date}`
-          : data.first_air_date
-            ? `첫 방영일: ${data.first_air_date}`
-            : '';
-
-        const tags = data.genres?.map((genre) => genre.name).join(' · ') || '';
-
-        setMovie({
-          title: data.title || data.name,
-          image: `https://image.tmdb.org/t/p/w500${data.backdrop_path || data.poster_path}`,
-          description: data.overview || '설명이 없습니다.',
-          subtitle,
-          tags,
-        });
-      } catch (error) {
-        console.error('상세 정보 로딩 실패:', error);
-      }
-    };
-
-    fetchDetails();
-  }, [isOpen, movieId, movieType]);
-
+const DetailModal = ({ isOpen, onClose, movieId, movieType }) => {
+  const movie = useDetailData(isOpen, movieId, movieType);
   const { addToMyList, removeFromMyList, isInMyList } = useMyList();
   const inMyList = movieId ? isInMyList(movieId) : false;
 

--- a/src/hooks/useDetailData.js
+++ b/src/hooks/useDetailData.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { instance } from '../api/axios';
+import { requests } from '../api/requests';
+
+export const useDetailData = (isOpen, movieId, movieType) => {
+  const [movie, setMovie] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen || !movieId || !movieType) return;
+
+    const fetchDetails = async () => {
+      try {
+        const url =
+          movieType === 'tv'
+            ? requests.fetchTVDetails(movieId)
+            : requests.fetchMovieDetails(movieId);
+
+        const res = await instance.get(url);
+        const data = res.data;
+
+        const subtitle = data.release_date
+          ? `개봉일: ${data.release_date}`
+          : data.first_air_date
+            ? `첫 방영일: ${data.first_air_date}`
+            : '';
+
+        const tags = data.genres?.map((genre) => genre.name).join(' · ') || '';
+
+        setMovie({
+          title: data.title || data.name,
+          image: `https://image.tmdb.org/t/p/w500${data.backdrop_path || data.poster_path}`,
+          description: data.overview || '설명이 없습니다.',
+          subtitle,
+          tags,
+        });
+      } catch (error) {
+        console.error('상세 정보 로딩 실패:', error);
+      }
+    };
+
+    fetchDetails();
+  }, [isOpen, movieId, movieType]);
+
+  return movie;
+};

--- a/src/hooks/useMixedContent.js
+++ b/src/hooks/useMixedContent.js
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { instance } from '../api/axios';
+import { requests } from '../api/requests';
+
+export const useMixedContent = () => {
+  const [rawMovies, setRawMovies] = useState([]);
+  const [rawTVs, setRawTVs] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchMixedContent = async () => {
+      try {
+        const [
+          netflixRes,
+          actionMovieRes,
+          comedyMovieRes,
+          horrorMovieRes,
+          romanceMovieRes,
+          actionTVRes,
+          comedyTVRes,
+          docTVRes,
+          dramaTVRes,
+          realityTVRes,
+        ] = await Promise.all([
+          instance.get(requests.fetchNetflixOriginals),
+          instance.get(requests.fetchActionMovies),
+          instance.get(requests.fetchComedyMovies),
+          instance.get(requests.fetchHorrorMovies),
+          instance.get(requests.fetchRomanceMovies),
+          instance.get(requests.fetchActionAdventureTV),
+          instance.get(requests.fetchComedyTV),
+          instance.get(requests.fetchDocumentaryTV),
+          instance.get(requests.fetchDramaTV),
+          instance.get(requests.fetchRealityTV),
+        ]);
+
+        setRawMovies([
+          ...netflixRes.data.results,
+          ...actionMovieRes.data.results,
+          ...comedyMovieRes.data.results,
+          ...horrorMovieRes.data.results,
+          ...romanceMovieRes.data.results,
+        ]);
+
+        setRawTVs([
+          ...actionTVRes.data.results,
+          ...comedyTVRes.data.results,
+          ...docTVRes.data.results,
+          ...dramaTVRes.data.results,
+          ...realityTVRes.data.results,
+        ]);
+      } catch (err) {
+        console.error('useMixedContent Error:', err);
+        setError(err);
+      }
+    };
+
+    fetchMixedContent();
+  }, []);
+
+  return { rawMovies, rawTVs, error };
+};

--- a/src/hooks/useMixedContent.js
+++ b/src/hooks/useMixedContent.js
@@ -1,62 +1,51 @@
+// useMixedContent.js
 import { useEffect, useState } from 'react';
 import { instance } from '../api/axios';
 import { requests } from '../api/requests';
 
-export const useMixedContent = () => {
+export const useMixedContent = (type = 'all') => {
   const [rawMovies, setRawMovies] = useState([]);
   const [rawTVs, setRawTVs] = useState([]);
-  const [error, setError] = useState(null);
 
   useEffect(() => {
-    const fetchMixedContent = async () => {
+    const fetchContent = async () => {
       try {
-        const [
-          netflixRes,
-          actionMovieRes,
-          comedyMovieRes,
-          horrorMovieRes,
-          romanceMovieRes,
-          actionTVRes,
-          comedyTVRes,
-          docTVRes,
-          dramaTVRes,
-          realityTVRes,
-        ] = await Promise.all([
-          instance.get(requests.fetchNetflixOriginals),
-          instance.get(requests.fetchActionMovies),
-          instance.get(requests.fetchComedyMovies),
-          instance.get(requests.fetchHorrorMovies),
-          instance.get(requests.fetchRomanceMovies),
-          instance.get(requests.fetchActionAdventureTV),
-          instance.get(requests.fetchComedyTV),
-          instance.get(requests.fetchDocumentaryTV),
-          instance.get(requests.fetchDramaTV),
-          instance.get(requests.fetchRealityTV),
-        ]);
+        const movieRequests = [
+          requests.fetchNetflixOriginals,
+          requests.fetchActionMovies,
+          requests.fetchComedyMovies,
+          requests.fetchHorrorMovies,
+          requests.fetchRomanceMovies,
+        ];
 
-        setRawMovies([
-          ...netflixRes.data.results,
-          ...actionMovieRes.data.results,
-          ...comedyMovieRes.data.results,
-          ...horrorMovieRes.data.results,
-          ...romanceMovieRes.data.results,
-        ]);
+        const tvRequests = [
+          requests.fetchActionAdventureTV,
+          requests.fetchComedyTV,
+          requests.fetchDocumentaryTV,
+          requests.fetchDramaTV,
+          requests.fetchRealityTV,
+        ];
 
-        setRawTVs([
-          ...actionTVRes.data.results,
-          ...comedyTVRes.data.results,
-          ...docTVRes.data.results,
-          ...dramaTVRes.data.results,
-          ...realityTVRes.data.results,
-        ]);
-      } catch (err) {
-        console.error('useMixedContent Error:', err);
-        setError(err);
+        if (type === 'movie' || type === 'all') {
+          const movieRes = await Promise.all(
+            movieRequests.map((url) => instance.get(url)),
+          );
+          setRawMovies(movieRes.flatMap((res) => res.data.results || []));
+        }
+
+        if (type === 'tv' || type === 'all') {
+          const tvRes = await Promise.all(
+            tvRequests.map((url) => instance.get(url)),
+          );
+          setRawTVs(tvRes.flatMap((res) => res.data.results || []));
+        }
+      } catch (error) {
+        console.error('콘텐츠 로딩 실패:', error);
       }
     };
 
-    fetchMixedContent();
-  }, []);
+    fetchContent();
+  }, [type]);
 
-  return { rawMovies, rawTVs, error };
+  return { rawMovies, rawTVs };
 };

--- a/src/hooks/useMixedContentData.js
+++ b/src/hooks/useMixedContentData.js
@@ -1,9 +1,8 @@
-// useMixedContent.js
 import { useEffect, useState } from 'react';
 import { instance } from '../api/axios';
 import { requests } from '../api/requests';
 
-export const useMixedContent = (type = 'all') => {
+export const useMixedContentData = (type = 'all') => {
   const [rawMovies, setRawMovies] = useState([]);
   const [rawTVs, setRawTVs] = useState([]);
 

--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -16,7 +16,7 @@ const Movies = () => {
   };
   return (
     <>
-      <Banner onInfoClick={openModal} />
+      <Banner onInfoClick={openModal} type="movie" />
       <DetailModal
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/src/pages/TVShows/TVShows.jsx
+++ b/src/pages/TVShows/TVShows.jsx
@@ -16,7 +16,7 @@ const TVShows = () => {
   };
   return (
     <>
-      <Banner onInfoClick={openModal} />
+      <Banner onInfoClick={openModal} type="tv" />
       <DetailModal
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}


### PR DESCRIPTION
# 📌 PR 제목

Banner/Modal API 분리: useMixedContentData, useDetailData 커스텀 훅 적용

---

## ✨ 변경사항

- Banner.jsx → useMixedContentData 훅으로 API 호출 분리
- DetailModal.jsx → useDetailData 훅으로 상세 정보 로직 분리
- 프리뷰 콘텐츠를 type(movie/tv/all)에 따라 분기 처리 가능하도록 개선

---

## 📋 작업 내용 상세

✅ useMixedContent 훅 적용 (Banner.jsx)
 - 기존의 10개 요청(fetchNetflixOriginals, fetchActionMovies 등)을 훅으로 추출
 - 반환된 rawMovies, rawTVs를 useMemo로 movieList, tvList로 가공
 - type props에 따라 프리뷰 썸네일(fetchTrending) 요청도 movie, tv, all 분기 처리

✅ useDetailData 훅 적용 (DetailModal.jsx) 
 - 기존의 movieId, movieType 기반 fetch 요청을 훅으로 추출
 - 반환되는 data, loading, error 활용하여 상세 콘텐츠 구성
 - 기존 useEffect 내부 로직 제거, useDetailData에서 처리
 
---

## ✅ 체크리스트

- [x] 코드에 오류가 없는지 확인했습니다.
- [x] 주석을 정리했습니다.
- [x] 문서화가 필요한 경우 문서 작성했습니다.
- [x] 테스트를 완료했습니다.

---

## 🚨 주의사항

 - type이 all인 경우, 영화/TV를 섞은 랜덤 콘텐츠가 Banner에 표시됩니다.
 - useDetailData는 isOpen이 true이고 movieId, movieType이 모두 있어야 동작합니다.

---

## 📎 관련 이슈

- Closes #40 
- Related to #40 
