### PR TITLE
Fix/banner preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.5.3"
+        "react-router-dom": "^7.5.3",
+        "swiper": "^11.2.6"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
@@ -6178,6 +6179,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.6.tgz",
+      "integrity": "sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.5.3"
+    "react-router-dom": "^7.5.3",
+    "swiper": "^11.2.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -94,7 +94,6 @@
 }
 
 .banner_previews_swiper {
-  padding-left: 12px;
 }
 
 .preview_item {

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -107,9 +107,8 @@
 }
 
 .preview_item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  width: 102px;
+  height: 102px;
   flex-shrink: 0;
 }
 
@@ -122,4 +121,8 @@
 
 .preview_item:first-child {
   margin-left: 12px;
+}
+
+.banner_previews_swiper {
+  padding-left: 12px;
 }

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -93,17 +93,8 @@
   margin-left: 12px;
 }
 
-.banner_previews_container {
-  width: 100%;
-  height: 102px;
-  display: flex;
-  overflow-x: auto;
-  gap: 12px;
-  scrollbar-width: none;
-}
-
-.banner_previews_container::-webkit-scrollbar {
-  display: none;
+.banner_previews_swiper {
+  padding-left: 12px;
 }
 
 .preview_item {
@@ -121,8 +112,4 @@
 
 .preview_item:first-child {
   margin-left: 12px;
-}
-
-.banner_previews_swiper {
-  padding-left: 12px;
 }

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -2,11 +2,11 @@ import { useEffect, useState, useMemo } from 'react';
 import { useContentData } from '../../hooks/useContentData';
 import { instance } from '../../services/api';
 import { requests } from '../../services/requests';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { useMyList } from '../../context/MyListContext';
 import MyListIcon from '../../assets/icon-mylist-plus.svg';
 import PlayIcon from '../../assets/icon-modal-play.svg';
 import InfoIcon from '../../assets/icon-info.svg';
-import { useMyList } from '../../context/MyListContext';
-import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import './Banner.css';
 

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -85,7 +85,7 @@ const Banner = ({ onInfoClick, type = 'all' }) => {
             media_type: item.media_type || (item.title ? 'movie' : 'tv'),
             genre_ids: item.genre_ids,
           }));
-        setPreviews(mapped);
+        setPreviews(mapped.slice(0, 20));
       } catch (err) {
         console.error('프리뷰 콘텐츠 로딩 실패:', err);
       }

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -6,6 +6,8 @@ import MyListIcon from '../../assets/icon-mylist-plus.svg';
 import PlayIcon from '../../assets/icon-modal-play.svg';
 import InfoIcon from '../../assets/icon-info.svg';
 import { useMyList } from '../../context/MyListContext';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
 import './Banner.css';
 
 const Banner = ({ onInfoClick, type = 'all' }) => {
@@ -135,17 +137,24 @@ const Banner = ({ onInfoClick, type = 'all' }) => {
           <div className="banner_preview">
             <p>Previews</p>
           </div>
-          <div className="banner_previews_container">
-            {previews.map((preview) => (
-              <div
-                className="preview_item"
-                key={preview.id}
-                onClick={() => onInfoClick(preview.id, preview.media_type)}
-              >
-                <img src={preview.image} alt={preview.title} />
-              </div>
+          <Swiper
+            spaceBetween={12}
+            slidesPerView={3.5}
+            className="banner_previews_swiper"
+            grabCursor={true}
+          >
+            {previews.map((content) => (
+              <SwiperSlide key={content.id}>
+                <div
+                  className="preview_item"
+                  onClick={() => onInfoClick(content.id, content.media_type)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <img src={content.image} alt={content.title} />
+                </div>
+              </SwiperSlide>
             ))}
-          </div>
+          </Swiper>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# 📌 PR 제목

Swiper 기반 Preview 슬라이드 구현

---

## ✨ 변경사항

- Banner.jsx에 Swiper 슬라이드 적용
- Preview 항목을 20개로 제한

---

## 📋 작업 내용 상세

- Preview 목록을 Swiper를 활용해 슬라이더 형식으로 시각화
- slidesPerView, spaceBetween, grabCursor 등 설정 적용

---

## ✅ 체크리스트

- [x] 코드에 오류가 없는지 확인했습니다.
- [x] 주석을 정리했습니다.
- [x] 문서화가 필요한 경우 문서 작성했습니다.
- [x] 테스트를 완료했습니다.

---

## 🚨 주의사항

- 모바일 터치가 개발자 도구에서 동작하지 않을 수 있으므로 실기기 테스트 필요
- Swiper 사용 시 SwiperSlide 내부에 DOM을 꼭 감싸야 layout이 깨지지 않음

---

## 📎 관련 이슈

- Closes #33 
- Related to #64 
