### PR TITLE
Refactor/row swiper

### DIFF
--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -137,13 +137,13 @@ const Banner = ({ onInfoClick, type = 'all' }) => {
             <p>Previews</p>
           </div>
           <Swiper
-            spaceBetween={12}
-            slidesPerView={3.5}
             className="banner_previews_swiper"
+            spaceBetween={12}
+            slidesPerView="auto"
             grabCursor={true}
           >
             {previews.map((content) => (
-              <SwiperSlide key={content.id}>
+              <SwiperSlide key={content.id} style={{ width: '102px' }}>
                 <div
                   className="preview_item"
                   onClick={() => onInfoClick(content.id, content.media_type)}

--- a/src/components/RowMovie/RowMovie.css
+++ b/src/components/RowMovie/RowMovie.css
@@ -14,16 +14,6 @@
   padding-left: 4px;
 }
 
-.row_posters {
-  display: flex;
-  overflow-x: scroll;
-  overflow-y: hidden;
-  gap: 8px;
-  padding-bottom: 4px;
-  padding-left: 4px;
-  scroll-behavior: smooth;
-}
-
 .row_swiper {
   padding-left: 4px;
   padding-bottom: 4px;
@@ -31,12 +21,6 @@
 
 .swiper_slide {
   width: auto !important;
-}
-
-.row_posters::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-  display: none;
 }
 
 .row_poster {

--- a/src/components/RowMovie/RowMovie.css
+++ b/src/components/RowMovie/RowMovie.css
@@ -24,6 +24,15 @@
   scroll-behavior: smooth;
 }
 
+.row_swiper {
+  padding-left: 4px;
+  padding-bottom: 4px;
+}
+
+.swiper_slide {
+  width: auto !important;
+}
+
 .row_posters::-webkit-scrollbar {
   width: 0;
   height: 0;

--- a/src/components/RowMovie/RowMovie.jsx
+++ b/src/components/RowMovie/RowMovie.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { instance } from '../../services/api';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
 import './RowMovie.css';
 
 const RowMovie = ({ title, fetchUrl, onInfoClick }) => {

--- a/src/components/RowMovie/RowMovie.jsx
+++ b/src/components/RowMovie/RowMovie.jsx
@@ -30,18 +30,24 @@ const RowMovie = ({ title, fetchUrl, onInfoClick }) => {
   return (
     <div className="row">
       <h2 className="row_title">{title}</h2>
-      <div className="row_posters">
+      <Swiper
+        spaceBetween={10}
+        slidesPerView={3.2}
+        grabCursor={true}
+        className="row_swiper"
+      >
         {items.map((item) => (
-          <img
-            key={item.id}
-            className="row_poster"
-            src={item.poster}
-            alt={item.title}
-            onClick={() => onInfoClick(item.id, item.media_type)}
-            style={{ cursor: 'pointer' }}
-          />
+          <SwiperSlide key={item.id}>
+            <img
+              className="row_poster"
+              src={item.poster}
+              alt={item.title}
+              onClick={() => onInfoClick(item.id, item.media_type)}
+              style={{ cursor: 'pointer' }}
+            />
+          </SwiperSlide>
         ))}
-      </div>
+      </Swiper>
     </div>
   );
 };

--- a/src/components/RowMovie/RowMovie.jsx
+++ b/src/components/RowMovie/RowMovie.jsx
@@ -31,13 +31,13 @@ const RowMovie = ({ title, fetchUrl, onInfoClick }) => {
     <div className="row">
       <h2 className="row_title">{title}</h2>
       <Swiper
-        spaceBetween={10}
-        slidesPerView={3.2}
-        grabCursor={true}
         className="row_swiper"
+        spaceBetween={8}
+        grabCursor={true}
+        slidesPerView="auto"
       >
         {items.map((item) => (
-          <SwiperSlide key={item.id}>
+          <SwiperSlide key={item.id} style={{ width: '103px' }}>
             <img
               className="row_poster"
               src={item.poster}


### PR DESCRIPTION
# 📌 PR 제목

RowMovie에 Swiper 적용 및 반응형 포스터 슬라이더 구현

---

## ✨ 변경사항

- RowMovie 컴포넌트에 Swiper 적용
- slidesPerView: 'auto' + spaceBetween 방식으로 반응형 구현
- 기존 포스터 간격(spaceBetween 8px) 유지

---

## 📋 작업 내용 상세

 - 기존 .row_posters의 수평 스크롤 방식 제거
 - SwiperSlide마다 포스터 고정 너비(width: 103px) 설정
 - slidesPerView: 'auto'를 사용하여 화면 너비에 따라 포스터 개수 유동적으로 렌더링
 - 데스크탑, 태블릿, 모바일 뷰 모두에서 자연스럽게 반응형 적용됨
 - Banner Previews에도 반응형 적용

---

## ✅ 체크리스트

- [ ] 코드에 오류가 없는지 확인했습니다.
- [ ] 주석을 정리했습니다.
- [ ] 문서화가 필요한 경우 문서 작성했습니다.
- [ ] 테스트를 완료했습니다.

---

## 🚨 주의사항

- Swiper 스타일이 전역에 영향을 주지 않도록 import 'swiper/css';는 컴포넌트에서 한 번만 호출
- slidesPerView가 'auto'일 때는 SwiperSlide에 명시적인 width가 있어야 포스터 크기가 유지됨

---

## 📎 관련 이슈

- Closes #이슈번호
- Related to #이슈번호
