### PR TITLE
fix: mylist에 remove 버튼 display 되도록 수정, 포스터 그리드 비율 명시

### DIFF
--- a/src/pages/MyList/MyList.css
+++ b/src/pages/MyList/MyList.css
@@ -31,6 +31,7 @@
 .poster {
   width: 100%;
   height: 100%;
+  aspect-ratio: 2 / 3;
   object-fit: cover;
   border-radius: 4px;
 }
@@ -46,7 +47,7 @@
   transition: opacity 0.3s ease;
 }
 
-.poster_container:hover .item_overlay {
+.mylist_item:hover .item_overlay {
   opacity: 1;
 }
 


### PR DESCRIPTION
# 📌 PR 제목

MyList 페이지 스타일링 개선
---

## ✨ 변경사항

- 포스터 이미지에 일관된 가로세로 비율(2:3) 적용
- 항목 호버 효과 선택자 수정으로 UI 상호작용 개선
- mylist 그리드 레이아웃 개선
---

## 📋 작업 내용 상세

- `.poster` 클래스에 `aspect-ratio: 2 / 3;` 속성을 추가하여 모든 포스터 이미지가 표준적인 영화 포스터 비율을 유지하도록 수정
- 호버 효과 선택자를 `.poster_container:hover .item_overlay`에서 `.mylist_item:hover .item_overlay`로 변경하여 컴포넌트 구조와 일치시키고 사용자 경험 개선

---

## ✅ 체크리스트

- [x] 코드에 오류가 없는지 확인했습니다.
- [ ] 주석을 정리했습니다.
- [x] 문서화가 필요한 경우 문서 작성했습니다.
- [x] 테스트를 완료했습니다.

---

## 🚨 주의사항
IE11과 같은 구형 브라우저에서는 aspect-ratio 속성이 지원되지 않을 수 있습니다.

---

## 📎 관련 이슈

